### PR TITLE
fix opam invocation

### DIFF
--- a/imandra-prelude.opam
+++ b/imandra-prelude.opam
@@ -7,7 +7,7 @@ homepage: "http://www.imandra.ai/"
 bug-reports: "Grant Passmore <grant@aestheticintegration.com>"
 license: "Apache 2"
 dev-repo: "git+https://github.com/AestheticIntegration/imandra-prelude"
-build: [make "build"]
+build: [["jbuilder" "build" "-p" name "-j" jobs]]
 depends: [
   "jbuilder" {build}
   "zarith"


### PR DESCRIPTION
We need to pass the `-p` flag to `jbuilder` otherwise it tries to build everything else, esp when using a local `./_opam` switch.